### PR TITLE
Added net461 back into target frameworks

### DIFF
--- a/Specflow.DSL.SpecflowPlugin/Specflow.DSL.SpecFlowPlugin.csproj
+++ b/Specflow.DSL.SpecflowPlugin/Specflow.DSL.SpecFlowPlugin.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net461;netstandard2.0</TargetFrameworks>
     <AssemblyName>Specflow.DSL.SpecFlowPlugin</AssemblyName>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>SpecFlow.DSL</PackageId>


### PR DESCRIPTION
As discussed in [PR 3](https://github.com/wenyuansong/Specflow.DSL/pull/3) there is a nuanced compatibility issue between .NET Framework 4.6.1 and .NET Standard 2.0. To increase compatibility we're adding the net461 target framework back into the library.

See below:
![image](https://github.com/wenyuansong/Specflow.DSL/assets/711576/de2170c9-b4b9-471a-8b1c-4e097c670e2a)
[source](https://learn.microsoft.com/en-us/dotnet/standard/library-guidance/cross-platform-targeting)
